### PR TITLE
Fix undefined reference to `mac_is_valid' error on GCC_ARM target

### DIFF
--- a/SDK/RDA5981_SDK_MbedOS515_V1.3.2/features/net/FEATURE_LWIP/lwip-interface/lwip-wifi/arch/TARGET_RDA/TARGET_UNO_91H/inc/rda5991h_wland.h
+++ b/SDK/RDA5981_SDK_MbedOS515_V1.3.2/features/net/FEATURE_LWIP/lwip-interface/lwip-wifi/arch/TARGET_RDA/TARGET_UNO_91H/inc/rda5991h_wland.h
@@ -74,7 +74,7 @@ typedef struct {
     sys_mbox_t wland_mbox;
 } rda_enetdata_t;
 
-__INLINE int mac_is_valid(char* mac)
+static __INLINE int mac_is_valid(char* mac)
 {
     return (mac[0] | mac[1] | mac[2] | mac[3] | mac[4] | mac[5]);
 }

--- a/SDK/RDA5981_SDK_MbedOS515_V1.3.4/features/net/FEATURE_LWIP/lwip-interface/lwip-wifi/arch/TARGET_RDA/TARGET_UNO_91H/inc/rda5991h_wland.h
+++ b/SDK/RDA5981_SDK_MbedOS515_V1.3.4/features/net/FEATURE_LWIP/lwip-interface/lwip-wifi/arch/TARGET_RDA/TARGET_UNO_91H/inc/rda5991h_wland.h
@@ -84,7 +84,7 @@ typedef struct {
     sys_mbox_t wland_mbox;
 } rda_enetdata_t;
 
-__INLINE int mac_is_valid(char* mac)
+static __INLINE int mac_is_valid(char* mac)
 {
     return (mac[0] | mac[1] | mac[2] | mac[3] | mac[4] | mac[5]);
 }

--- a/SDK/RDA5981_SDK_MbedOS515_V1.3.5/features/net/FEATURE_LWIP/lwip-interface/lwip-wifi/arch/TARGET_RDA/TARGET_UNO_91H/inc/rda5991h_wland.h
+++ b/SDK/RDA5981_SDK_MbedOS515_V1.3.5/features/net/FEATURE_LWIP/lwip-interface/lwip-wifi/arch/TARGET_RDA/TARGET_UNO_91H/inc/rda5991h_wland.h
@@ -84,7 +84,7 @@ typedef struct {
     sys_mbox_t wland_mbox;
 } rda_enetdata_t;
 
-__INLINE int mac_is_valid(char* mac)
+static __INLINE int mac_is_valid(char* mac)
 {
     return (mac[0] | mac[1] | mac[2] | mac[3] | mac[4] | mac[5]);
 }


### PR DESCRIPTION
On RDA5981_SDK_MbedOS515_V1.3.5 and older versions, I got linkage error when we tried to `mbed compile` Wi-Fi related examples located under `TESTS/TARGET_RDA/` (like esptouch, sniffer, wifistack) with GCC_ARM target.

```
$ mbed compile -m UNO_91H -t GCC_ARM --source TESTS/TARGET_RDA/esptouch/ --source ./ -c
...
Link: esptouch
./BUILD/UNO_91H/GCC_ARM/features/net/FEATURE_LWIP/lwip-interface/lwip-wifi/arch/TARGET_RDA/TARGET_UNO_91H/src/rda5991h_wland.o: In function `mbed_mac_address':
rda5991h_wland.c:(.text.mbed_mac_address+0x6): undefined reference to `mac_is_valid'
rda5991h_wland.c:(.text.mbed_mac_address+0x10): undefined reference to `mac_is_valid'
collect2.exe: error: ld returned 1 exit status
[ERROR] ./BUILD/UNO_91H/GCC_ARM/features/net/FEATURE_LWIP/lwip-interface/lwip-wifi/arch/TARGET_RDA/TARGET_UNO_91H/src/rda5991h_wland.o: In function `mbed_mac_address':
rda5991h_wland.c:(.text.mbed_mac_address+0x6): undefined reference to `mac_is_valid'
rda5991h_wland.c:(.text.mbed_mac_address+0x10): undefined reference to `mac_is_valid'
collect2.exe: error: ld returned 1 exit status
...
```

This linkage error occurs because modifier of `mac_is_valid` function defined in `rda5991h_wland.h` is invalid and cannot be referred from `rda5991h_wland.c`.

To fix this, we should add `static` modifier to the function likewise other inline functions in the SDK. 

So it have to be `static __INLINE int mac_is_valid(char* mac) ...`, then compile finished successfully.